### PR TITLE
added notifications when content is flagged

### DIFF
--- a/app/models/custom/flag.rb
+++ b/app/models/custom/flag.rb
@@ -1,0 +1,37 @@
+class Flag < ApplicationRecord
+  belongs_to :user
+  belongs_to :flaggable, polymorphic: true, counter_cache: true, touch: true
+
+  scope(:by_user_and_flaggable, lambda do |user, flaggable|
+    where(user_id: user.id,
+          flaggable_type: flaggable.class.to_s,
+          flaggable_id: flaggable.id)
+  end)
+
+  scope :for_comments, ->(comments) { where(flaggable_type: "Comment", flaggable_id: comments) }
+
+  def self.flag(user, flaggable)
+    return false if flagged?(user, flaggable)
+
+    create!(user: user, flaggable: flaggable)
+      alert_title = "Moderation alert"
+      alert_body = "An item has been flagged for moderation"
+      alert_link = "/moderation"
+      admin_notification = AdminNotification.new(title: alert_title, body: alert_body, segment_recipient: "administrators", link: "/moderation")
+      admin_notification.save
+      admin_notification.deliver
+  end
+
+  def self.unflag(user, flaggable)
+    flags = by_user_and_flaggable(user, flaggable)
+    return false if flags.empty?
+
+    flags.destroy_all
+  end
+
+  def self.flagged?(user, flaggable)
+    return false unless user
+
+    !!by_user_and_flaggable(user, flaggable)&.first
+  end
+end


### PR DESCRIPTION
## References

> Related Issues/Pull Requests/errors/etc...

## Objectives

Add notifications to moderation so that users are aware when content has been flagged

## Visual Changes

![image](https://user-images.githubusercontent.com/102246590/226418881-d1bb61b1-2bde-456d-ad88-c1dbab0dd087.png)


## Notes

Still need to check whether emails are being sent and there is probably a better way of doing it, but for the time being it works and is in a custom file so shouldn't break too much
