### PR TITLE
Adding an additional cosla experimental tab to settings

### DIFF
--- a/app/controllers/custom/admin/settings_controller.rb
+++ b/app/controllers/custom/admin/settings_controller.rb
@@ -1,0 +1,65 @@
+class Admin::SettingsController < Admin::BaseController
+  def index
+    all_settings = Setting.all.group_by(&:type)
+    @configuration_settings = all_settings["configuration"]
+    @feature_settings = all_settings["feature"]
+    @participation_processes_settings = all_settings["process"]
+    @map_configuration_settings = all_settings["map"]
+    @proposals_settings = all_settings["proposals"]
+    @remote_census_general_settings = all_settings["remote_census.general"]
+    @remote_census_request_settings = all_settings["remote_census.request"]
+    @remote_census_response_settings = all_settings["remote_census.response"]
+    @uploads_settings = all_settings["uploads"]
+    @sdg_settings = all_settings["sdg"]
+    @cosla_settings = all_settings["cosla_setting"]
+    @cosla_features = all_settings["cosla_feature"]
+    puts all_settings["cosla_feature"]
+  end
+
+  def update
+    @setting = Setting.find(params[:id])
+    @setting.update!(settings_params)
+
+    respond_to do |format|
+      format.html { redirect_to request_referer, notice: t("admin.settings.flash.updated") }
+      format.js
+    end
+  end
+
+  def update_map
+    Setting["map.latitude"] = params[:latitude].to_f
+    Setting["map.longitude"] = params[:longitude].to_f
+    Setting["map.zoom"] = params[:zoom].to_i
+    redirect_to admin_settings_path, notice: t("admin.settings.index.map.flash.update")
+  end
+
+  def update_content_types
+    setting = Setting.find(params[:id])
+    group = setting.content_type_group
+    mime_type_values = content_type_params.keys.map do |content_type|
+      Setting.mime_types[group][content_type]
+    end
+    setting.update! value: mime_type_values.join(" ")
+    redirect_to admin_settings_path, notice: t("admin.settings.flash.updated")
+  end
+
+  private
+
+    def settings_params
+      params.require(:setting).permit(allowed_params)
+    end
+
+    def allowed_params
+      [:value]
+    end
+
+    def content_type_params
+      params.permit(:jpg, :png, :gif, :pdf, :doc, :docx, :xls, :xlsx, :csv, :zip)
+    end
+
+    def request_referer
+      return request.referer + params[:setting][:tab] if params[:setting][:tab]
+
+      request.referer
+    end
+end

--- a/app/models/custom/setting.rb
+++ b/app/models/custom/setting.rb
@@ -24,7 +24,17 @@ class Setting
       else
         consul_defaults.merge({
           # Overwrite default CONSUL settings or add new settings here
-        })
+          "cosla_feature.openai": true,
+          "cosla_feature.header": false,
+          "cosla_feature.govnotify": false,
+          # Enable openai moderation. Requires api key from openai and ruby-openai gem
+          "cosla_setting.openai_moderation_api_key": "",
+          # openai moderation setting,
+          "cosla_setting.openai_moderation_threshhold": "1.5",
+          "cosla_setting.govnotify_api_key":"",
+          # api key for gov notify service,
+          "cosla_setting.openai_moderation.test":"A very bad phrase"
+                })
       end
     end
   end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -8,7 +8,7 @@ class Setting < ApplicationRecord
   end
 
   def type
-    if %w[feature process proposals map html homepage uploads sdg machine_learning].include? prefix
+    if %w[feature process proposals map html homepage uploads sdg machine_learning cosla_setting cosla_feature].include? prefix
       prefix
     elsif %w[remote_census].include? prefix
       key.rpartition(".").first
@@ -31,7 +31,7 @@ class Setting < ApplicationRecord
 
   class << self
     def [](key)
-      where(key: key).pluck(:value).first.presence
+      where(key: key).pick(:value).presence
     end
 
     def []=(key, value)
@@ -42,7 +42,7 @@ class Setting < ApplicationRecord
 
     def rename_key(from:, to:)
       if where(key: to).empty?
-        value = where(key: from).pluck(:value).first.presence
+        value = where(key: from).pick(:value).presence
         create!(key: to, value: value)
       end
       remove(from)
@@ -84,7 +84,6 @@ class Setting < ApplicationRecord
         "feature.google_login": true,
         "feature.twitter_login": true,
         "feature.wordpress_login": false,
-        "feature.saml_login": false,
         "feature.public_stats": true,
         "feature.signature_sheets": true,
         "feature.user.recommendations": true,
@@ -131,7 +130,7 @@ class Setting < ApplicationRecord
         "uploads.images.title.min_length": 4,
         "uploads.images.title.max_length": 80,
         "uploads.images.min_width": 0,
-        "uploads.images.min_height": 768,
+        "uploads.images.min_height": 475,
         "uploads.images.max_size": 1,
         "uploads.images.content_types": "image/jpeg",
         "uploads.documents.max_amount": 3,
@@ -160,16 +159,14 @@ class Setting < ApplicationRecord
         "twitter_handle": nil,
         "twitter_hashtag": nil,
         "youtube_handle": nil,
-        "url": "http://example.com", # Public-facing URL of the app.
-        # CONSUL installation's organization name
-        "org_name": "CONSUL",
+        "org_name": default_org_name,
         "meta_title": nil,
         "meta_description": nil,
         "meta_keywords": nil,
         "proposal_notification_minimum_interval_in_days": 3,
         "direct_message_max_per_day": 3,
-        "mailer_from_name": "CONSUL",
-        "mailer_from_address": "noreply@consul.dev",
+        "mailer_from_name": default_org_name,
+        "mailer_from_address": default_mailer_from_address,
         "min_age_to_participate": 16,
         "hot_score_period_in_days": 31,
         "related_content_score_threshold": -0.3,
@@ -199,6 +196,18 @@ class Setting < ApplicationRecord
         "sdg.process.budgets": true,
         "sdg.process.legislation": true
       }
+    end
+
+    def default_org_name
+      Tenant.current&.name || default_main_org_name
+    end
+
+    def default_main_org_name
+      "CONSUL"
+    end
+
+    def default_mailer_from_address
+      "noreply@#{Tenant.current_host.presence || "consul.dev"}"
     end
 
     def reset_defaults

--- a/app/views/custom/admin/settings/_cosla_configuration_tab.html.erb
+++ b/app/views/custom/admin/settings/_cosla_configuration_tab.html.erb
@@ -1,0 +1,9 @@
+<% if feature?(:cosla) %>
+  <h2><%= t("admin.settings.index.cosla.title") %></h2>
+  <%= render "featured_settings_table", features: @cosla_features, tab: "#tab-cosla-configuration" %>
+  <%= render "settings_table", settings: @cosla_settings, setting_name: "Setting", tab: "#tab-cosla-configuration" %>
+<% else %>
+  <div class="callout primary">
+    <%= t("admin.settings.index.cosla.how_to_enable") %>
+  </div>
+<% end %>

--- a/app/views/custom/admin/settings/_filter_subnav.html.erb
+++ b/app/views/custom/admin/settings/_filter_subnav.html.erb
@@ -1,0 +1,61 @@
+<ul class="tabs"
+    id="settings-tabs"
+    data-deep-link="true"
+    data-update-history="true"
+    data-deep-link-smudge="true"
+    data-deep-link-smudge-delay="500"
+    data-tabs>
+  <li class="tabs-title is-active">
+    <%= link_to "#tab-configuration" do %>
+      <%= t("admin.settings.index.general") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title" id="participation-processes-tab">
+    <%= link_to "#tab-participation-processes" do %>
+      <%= t("admin.settings.index.participation_processes") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title" id="features-tab">
+    <%= link_to "#tab-feature-flags" do %>
+      <%= t("admin.settings.index.feature_flags") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title" id="map-tab">
+    <%= link_to "#tab-map-configuration" do %>
+      <%= t("admin.settings.index.map.title") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title" id="images-and-documents-tab">
+    <%= link_to "#tab-images-and-documents" do %>
+      <%= t("admin.settings.index.images_and_documents") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title" id="proposals-tab">
+    <%= link_to "#tab-proposals" do %>
+      <%= t("admin.settings.index.dashboard.title") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title" id="remote-census-tab">
+   <%= link_to "#tab-remote-census-configuration" do %>
+      <%= t("admin.settings.index.remote_census.title") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title" id="sdg-tab">
+   <%= link_to "#tab-sdg-configuration" do %>
+      <%= t("admin.settings.index.sdg.title") %>
+    <% end %>
+  </li>
+
+  <li class="tabs-title" id="cosla-tab">
+   <%= link_to "#tab-cosla-configuration" do %>
+      <%= t("admin.settings.index.cosla.title") %>
+    <% end %>
+  </li>
+</ul>

--- a/app/views/custom/admin/settings/index.html.erb
+++ b/app/views/custom/admin/settings/index.html.erb
@@ -1,0 +1,40 @@
+<h1><%= t("admin.settings.index.title") %></h1>
+<div class="tabs-content" data-tabs-content="settings-tabs">
+  <%= render "filter_subnav" %>
+
+  <div class="tabs-panel is-active" id="tab-configuration">
+    <%= render "configuration_settings_tab" %>
+  </div>
+
+  <div class="tabs-panel" id="tab-participation-processes">
+    <%= render "participation_processes_tab" %>
+  </div>
+
+  <div class="tabs-panel" id="tab-feature-flags">
+    <%= render "features_tab" %>
+  </div>
+
+  <div class="tabs-panel" id="tab-map-configuration">
+    <%= render "map_configuration_tab" %>
+  </div>
+
+  <div class="tabs-panel" id="tab-images-and-documents">
+    <%= render "images_and_documents_tab" %>
+  </div>
+
+  <div class="tabs-panel" id="tab-proposals">
+    <%= render "proposals_dashboard" %>
+  </div>
+
+  <div class="tabs-panel" id="tab-remote-census-configuration">
+    <%= render "remote_census_configuration_tab" %>
+  </div>
+
+  <div class="tabs-panel" id="tab-sdg-configuration">
+    <%= render "sdg_configuration_tab" %>
+  </div>
+
+  <div class="tabs-panel" id="tab-cosla-configuration">
+    <%= render "cosla_configuration_tab" %>
+  </div>
+</div>

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -528,10 +528,10 @@ en:
         size: "Size"
         url: "URL"
       create:
-        success_notice: "Document uploaded succesfully"
+        success_notice: "Document uploaded successfully"
         unable_notice: "Invalid document"
       destroy:
-        success_notice: "Document deleted succesfully"
+        success_notice: "Document deleted successfully"
     hidden_users:
       index:
         filter: Filter
@@ -619,7 +619,6 @@ en:
           title: Proposals
           back: Back
           id: Id
-          title: Title
           supports: Total supports
         form:
           custom_categories: Categories
@@ -723,6 +722,9 @@ en:
       proposals_topics: Proposals topics
       budgets: Participatory budgets
       geozones: Manage geozones
+      postcodes: Manage postcodes
+
+
       hidden_comments: Hidden comments
       hidden_debates: Hidden debates
       hidden_proposals: Hidden proposals
@@ -785,6 +787,7 @@ en:
       comments: "Comments"
       local_census_records: Manage local census
       machine_learning: "AI / Machine learning"
+      multitenancy: Multitenancy
     administrators:
       index:
         title: Administrators
@@ -894,7 +897,7 @@ en:
         pending_to_be_sent: This is the content pending to be sent
         moderate_pending: Moderate notification send
         send_pending: Send pending
-        send_pending_notification: Pending notifications sent succesfully
+        send_pending_notification: Pending notifications sent successfully
       proposal_notification_digest:
         title: "Proposal notification digest"
         description: "Gathers all proposal notifications for an user in a single message, to avoid too much emails."
@@ -1103,13 +1106,14 @@ en:
         table_title: "Title"
         edit_answers: Edit answers
         see_proposal: "(See proposal)"
-      flash:
-        question_added: "Question added to this poll"
-        error_on_question_added: "Question could not be assigned to this poll"
       destroy:
         alert: "This action will remove the poll and all its associated questions."
         success_notice: "Poll deleted successfully"
         unable_notice: "You cannot delete a poll that has votes"
+      votation_type:
+        title: "Votation type"
+        unique_description: "It's only possible to answer one time to the question."
+        multiple_description: "Allows to choose multiple answers. It's possible to set the maximum number of answers."
     questions:
       index:
         title: "Questions"
@@ -1126,9 +1130,13 @@ en:
         poll_not_assigned: "Poll not assigned"
       edit:
         title: "Edit Question"
+      form:
+        poll_help: "You can only select polls that have not started yet"
       new:
         title: "Create question to poll %{poll}"
         title_proposal: "Create question"
+      destroy:
+        notice: "Question deleted successfully"
       answers:
         images:
           add_image: "Add image"
@@ -1152,17 +1160,17 @@ en:
           documents_list: Documents list
           document_title: Title
           document_actions: Actions
+      no_edit: "Once the poll has started it will not be possible to create, edit or delete questions, answers or any content associated with the poll."
     answers:
       new:
         title: New answer
-      show:
-        title: Title
-        description: Description
-        images: Images
-        images_list: Images list
-        edit: Edit answer
       edit:
         title: Edit answer
+      destroy:
+        success_notice: "Answer deleted successfully"
+      images:
+        index:
+          title: Images
       videos:
         index:
           title: Videos
@@ -1315,7 +1323,7 @@ en:
           title: Map configuration
           help: Here you can customize the way the map is displayed to users. Drag map marker or click anywhere over the map, set desired zoom and click button "Update".
           flash:
-            update: Map configuration updated succesfully.
+            update: Map configuration updated successfully.
           form:
             submit: Update
           how_to_enable: 'To show the map to users you must enable "Proposals and budget investments geolocation" on "Features" tab.'
@@ -1327,6 +1335,9 @@ en:
         sdg:
           title: SDG configuration
           how_to_enable: 'To show the configuration options from Sustainable Development Goals you must enable "SDG" on "Features" tab.'
+        cosla:
+          title: Experimental configuration
+          how_to_enable: 'To show the configuration options from Cosla Experimental you must enable Cosla" on "Features" tab.'
       remote_census_general_name: General Information
       remote_census_request_name: Request Data
       remote_census_response_name: Response Data
@@ -1346,6 +1357,7 @@ en:
         label:
           booths: "Search booth by name or location"
           budget_investments: "Search investments by title, description or heading"
+          comments: "Search comments"
           debates: "Search debates by title or description"
           legislation_processes: "Search processes by title or description"
           legislation_proposals: "Search proposals by title or description"
@@ -1355,6 +1367,7 @@ en:
           poll_questions: "Search poll questions"
           polls: "Search polls by name or description"
           proposals: "Search proposals by title, code, description or question"
+          proposal_notifications: "Search notifications by title or description"
           users: "Search user by name or email"
         search: "Search"
       search_results: "Search results"
@@ -1396,7 +1409,30 @@ en:
         creating: Create district
       delete:
         success: Geozone successfully deleted
-        error: This geozone can't be deleted since there are elements attached to it
+        error: "This geozone can't be deleted since there are elements attached to it"
+      postcodes:
+       index:
+        title: Postcode
+        create: Create postcode
+      postcode:
+        name: Name
+        external_code: External code
+        census_code: Census code
+        code_help: Response code for this postcode on the census API
+        coordinates: Coordinates
+        coordinates_help: Coordinates that will generate a clickable area on an HTML image map
+      edit:
+        form:
+          submit_button: Save changes
+        editing: Editing postcode
+        back: Go back
+      new:
+        back: Go back
+        creating: Create district
+      delete:
+        success: postcode successfully deleted
+        error: This postcode can't be deleted since there are elements attached to it
+
     signature_sheets:
       author: Author
       created_at: Creation date
@@ -1621,6 +1657,25 @@ en:
             notice: "Card updated successfully"
           destroy:
             notice: "Card removed successfully"
+    tenants:
+      create:
+        notice: Tenant created successfully
+      form:
+        use_subdomain: "Use a subdomain in the %{domain} domain to access this tenant"
+        use_domain: "Use a different domain to access this tenant"
+      hide:
+        notice: Tenant disabled successfully
+      index:
+        create: Create tenant
+        enable: "Enable tenant %{tenant}"
+        enabled: Enabled
+      new:
+        admin_information: "When you create a tenant, your current user <strong>\"%{username}\"</strong> with the email <strong>\"%{email}\"</strong> and your password will be copied into the new tenant's database and will be automatically granted administration permissions. Note that these user accounts are stored in completely separate databases, so if you change the password of your user in one tenant, your accounts in other tenants will remain intact."
+        title: New tenant
+      restore:
+        notice: Tenant enabled successfully
+      update:
+        notice: Tenant updated successfully
     homepage:
       title: Homepage
       description: The active modules appear in the homepage in the same order as here.

--- a/config/locales/en/settings.yml
+++ b/config/locales/en/settings.yml
@@ -40,8 +40,6 @@ en:
     telegram_handle_description: "If filled in it will appear in the footer"
     instagram_handle: "Instagram handle"
     instagram_handle_description: "If filled in it will appear in the footer"
-    url: "Main URL"
-    url_description: "Main URL of your website"
     org_name: "Site name"
     org_name_description: "This name will appear on mailers subject, help pages..."
     related_content_score_threshold: "Related content score threshold"
@@ -93,8 +91,6 @@ en:
       google_login_description: "Allow users to sign up with their Google Account"
       wordpress_login: "Wordpress login"
       wordpress_login_description: "Allow users to sign up with their Wordpress Account"
-      saml_login: "Saml login"
-      saml_login_description: "Allow users to sign up with their Saml Account"
       featured_proposals: "Featured proposals"
       featured_proposals_description: "Shows featured proposals on index proposals page"
       signature_sheets: "Signature sheets"
@@ -229,3 +225,11 @@ en:
         budgets_description: Allow participatory budgets to be linked to Sustainable Development Goals
         legislation: Related SDG in collaborative legislation
         legislation_description: Allow collaborative legislation to be linked to Sustainable Development Goals
+    cosla_feature_settings:
+        openai_moderation_api_key: Openai moderation key
+        openai_moderation_api_key_description: Openai api key required to access openai models
+        openai_moderation_threshhold: Openai flag threshold
+        openai_moderation_threshhold_description: Value to be used for flagging or hiding content
+    cosla_settings:
+        openai: openai moderation
+        


### PR DESCRIPTION
using custom files where possible but forced to make changes to app/models/setting.rb and to the two locales files new settings are being populated using app/models/custom/setting.rb


## Objectives

Give us the ability to switch on and off experimental features. Intended to facilitate the inclusion of api keys and other settings for openai, govnotify and other items

## Visual Changes

![image](https://user-images.githubusercontent.com/102246590/229145802-0bd7e5f9-139f-4dae-a1f8-cb8e2b3de95d.png)


## Notes

requires the new settings to be included fromcustom/setting.rb which is run when deployed or by using rake settings:add_new_settings

